### PR TITLE
pulling the hello-express image with the tag  main in kubernetes

### DIFF
--- a/kubernetes/01-hello-express-dpl.yaml
+++ b/kubernetes/01-hello-express-dpl.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: hello-express
-        image: bayar/hello-express
+        image: bayar/hello-express:main
         ports:
         - name: http
           containerPort: 8080


### PR DESCRIPTION
GitHub action is pushing the docker image to the docker hub with the tag main

Updated Kubernetes deployment files to retrieve that instead of latest